### PR TITLE
Bug fixes and missing fields

### DIFF
--- a/Kucoin.Net/Objects/KucoinStreamMatchBase.cs
+++ b/Kucoin.Net/Objects/KucoinStreamMatchBase.cs
@@ -1,4 +1,6 @@
-﻿using Kucoin.Net.Converters;
+﻿using System;
+using CryptoExchange.Net.Converters;
+using Kucoin.Net.Converters;
 using Newtonsoft.Json;
 
 namespace Kucoin.Net.Objects
@@ -42,5 +44,11 @@ namespace Kucoin.Net.Objects
         /// The id of the trade
         /// </summary>
         public string TradeId { get; set; } = string.Empty;
+        /// <summary>
+        /// Gets time of the trade match
+        /// </summary>
+        [JsonProperty("ts"), JsonConverter(typeof(TimestampNanoSecondsConverter))]
+        public DateTime Timestamp { get; set; }
+
     }
 }

--- a/Kucoin.Net/SubClients/KucoinClientFutures.cs
+++ b/Kucoin.Net/SubClients/KucoinClientFutures.cs
@@ -298,8 +298,8 @@ namespace Kucoin.Net.SubClients
             parameters.AddParameter("leverage", leverage.ToString(CultureInfo.InvariantCulture));
             parameters.AddParameter("size", size.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("remark", remark);
-            parameters.AddOptionalParameter("stop", JsonConvert.SerializeObject(stopType, new StopTypeConverter(false)));
-            parameters.AddOptionalParameter("stopPriceType", JsonConvert.SerializeObject(stopPriceType, new StopPriceTypeConverter(false)));
+            parameters.AddOptionalParameter("stop", stopType != null ? JsonConvert.SerializeObject(stopType, new StopTypeConverter(false)) : null);
+            parameters.AddOptionalParameter("stopPriceType", stopPriceType != null ? JsonConvert.SerializeObject(stopPriceType, new StopPriceTypeConverter(false)) : null);
             parameters.AddOptionalParameter("stopPrice", stopPrice?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptionalParameter("reduceOnly", reduceOnly?.ToString());
             parameters.AddOptionalParameter("closeOrder", closeOrder?.ToString());


### PR DESCRIPTION
Add Timestamp field to StreamMatchBase.cs so that tradeupdates have a timestamp.
Fix issue where optional parameters were not working orders and so stop and stoppricetype were being sent even if null causing an issue with exchange.