### PR TITLE
fix(isolated margin risk limit)

### DIFF
--- a/Kucoin.Net/Clients/SpotApi/KucoinClientSpotApiAccount.cs
+++ b/Kucoin.Net/Clients/SpotApi/KucoinClientSpotApiAccount.cs
@@ -20,6 +20,7 @@ namespace Kucoin.Net.Clients.SpotApi
     public class KucoinClientSpotApiAccount : IKucoinClientSpotApiAccount
     {
         private readonly KucoinClientSpotApi _baseClient;
+
         internal KucoinClientSpotApiAccount(KucoinClientSpotApi baseClient)
         {
             _baseClient = baseClient;
@@ -135,7 +136,6 @@ namespace Kucoin.Net.Clients.SpotApi
                 { "type", JsonConvert.SerializeObject(accountType, new AccountTypeConverter(false, true))}
             };
             return await _baseClient.Execute<KucoinTransferableAccount>(_baseClient.GetUri("accounts/transferable"), HttpMethod.Get, ct, parameters, true).ConfigureAwait(false);
-
         }
 
         /// <inheritdoc />
@@ -281,17 +281,22 @@ namespace Kucoin.Net.Clients.SpotApi
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<IEnumerable<KucoinRiskLimit>>> GetRiskLimitAsync(bool? isolated = null, CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<KucoinRiskLimitCrossMargin>>> GetRiskLimitCrossMarginAsync(CancellationToken ct = default)
+        {
+            return await _baseClient.Execute<IEnumerable<KucoinRiskLimitCrossMargin>>(_baseClient.GetUri($"risk/limit/strategy"), HttpMethod.Get, ct, signed: true).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<KucoinRiskLimitIsolatedMargin>>> GetRiskLimitIsolatedMarginAsync(CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>();
-            parameters.AddOptionalParameter("marginModel", isolated == true ? "isolated": null);
-            return await _baseClient.Execute<IEnumerable<KucoinRiskLimit>>(_baseClient.GetUri($"risk/limit/strategy"), HttpMethod.Get, ct, parameters, signed: true).ConfigureAwait(false);
+            parameters.AddOptionalParameter("marginModel", "isolated");
+            return await _baseClient.Execute<IEnumerable<KucoinRiskLimitIsolatedMargin>>(_baseClient.GetUri($"risk/limit/strategy"), HttpMethod.Get, ct, parameters, signed: true).ConfigureAwait(false);
         }
 
         internal async Task<WebCallResult<KucoinToken>> GetWebsocketToken(bool authenticated, CancellationToken ct = default)
         {
             return await _baseClient.Execute<KucoinToken>(_baseClient.GetUri(authenticated ? "bullet-private" : "bullet-public"), method: HttpMethod.Post, ct, signed: authenticated).ConfigureAwait(false);
         }
-
     }
 }

--- a/Kucoin.Net/Clients/SpotApi/KucoinClientSpotApiExchangeData.cs
+++ b/Kucoin.Net/Clients/SpotApi/KucoinClientSpotApiExchangeData.cs
@@ -20,6 +20,7 @@ namespace Kucoin.Net.Clients.SpotApi
     public class KucoinClientSpotApiExchangeData : IKucoinClientSpotApiExchangeData
     {
         private readonly KucoinClientSpotApi _baseClient;
+
         internal KucoinClientSpotApiExchangeData(KucoinClientSpotApi baseClient)
         {
             _baseClient = baseClient;
@@ -173,6 +174,12 @@ namespace Kucoin.Net.Clients.SpotApi
                 { "currency", asset }
             };
             return await _baseClient.Execute<IEnumerable<KucoinBorrowOrderDetails>>(_baseClient.GetUri("margin/trade/last"), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<IEnumerable<KucoinTradingPairConfiguration>>> GetMarginTradingPairConfigurationAsync(CancellationToken ct = default)
+        {
+            return await _baseClient.Execute<IEnumerable<KucoinTradingPairConfiguration>>(_baseClient.GetUri($"isolated/symbols"), HttpMethod.Get, ct, signed: true).ConfigureAwait(false);
         }
     }
 }

--- a/Kucoin.Net/Interfaces/Clients/SpotApi/IKucoinClientSpotApiAccount.cs
+++ b/Kucoin.Net/Interfaces/Clients/SpotApi/IKucoinClientSpotApiAccount.cs
@@ -249,12 +249,18 @@ namespace Kucoin.Net.Interfaces.Clients.SpotApi
         Task<WebCallResult<object>> CancelWithdrawalAsync(string withdrawalId, CancellationToken ct = default);
 
         /// <summary>
-        /// Get cross or isolated margin risk limit
+        /// Get cross margin risk limit
         /// </summary>
-        /// <param name="isolated">Request isolated info, default cross info is returned</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<IEnumerable<KucoinRiskLimit>>> GetRiskLimitAsync(bool? isolated = null, CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<KucoinRiskLimitCrossMargin>>> GetRiskLimitCrossMarginAsync(CancellationToken ct = default);
+
+        /// <summary>
+        /// Get isolated margin risk limit
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<IEnumerable<KucoinRiskLimitIsolatedMargin>>> GetRiskLimitIsolatedMarginAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get margin account info

--- a/Kucoin.Net/Interfaces/Clients/SpotApi/IKucoinClientSpotApiExchangeData.cs
+++ b/Kucoin.Net/Interfaces/Clients/SpotApi/IKucoinClientSpotApiExchangeData.cs
@@ -48,7 +48,6 @@ namespace Kucoin.Net.Interfaces.Clients.SpotApi
         /// <returns>List of tickers</returns>
         Task<WebCallResult<KucoinTicks>> GetTickersAsync(CancellationToken ct = default);
 
-
         /// <summary>
         /// Gets the 24 hour stats of a symbol
         /// <para><a href="https://docs.kucoin.com/#get-24hr-stats" /></para>
@@ -57,7 +56,6 @@ namespace Kucoin.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns>24 hour stats</returns>
         Task<WebCallResult<Kucoin24HourStat>> Get24HourStatsAsync(string symbol, CancellationToken ct = default);
-
 
         /// <summary>
         /// Gets a list of supported markets
@@ -165,5 +163,13 @@ namespace Kucoin.Net.Interfaces.Clients.SpotApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<IEnumerable<KucoinBorrowOrderDetails>>> GetMarginTradeHistoryAsync(string asset, CancellationToken ct = default);
+
+        /// <summary>
+        /// Get Margin Trading Pair ConfigurationAsync
+        /// <para><a href="https://docs.kucoin.com/#query-isolated-margin-trading-pair-configuration" /></para>
+        /// </summary>
+        /// <param name="ct">Cancellation token</param> 
+        /// <returns></returns>
+        Task<WebCallResult<IEnumerable<KucoinTradingPairConfiguration>>> GetMarginTradingPairConfigurationAsync(CancellationToken ct = default);
     }
 }

--- a/Kucoin.Net/Kucoin.Net.xml
+++ b/Kucoin.Net/Kucoin.Net.xml
@@ -428,7 +428,10 @@
         <member name="M:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiAccount.GetMarginAccountAsync(System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiAccount.GetRiskLimitAsync(System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiAccount.GetRiskLimitCrossMarginAsync(System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiAccount.GetRiskLimitIsolatedMarginAsync(System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="T:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiExchangeData">
@@ -2521,11 +2524,17 @@
             <param name="ct">Cancellation token</param>
             <returns>Null</returns>
         </member>
-        <member name="M:Kucoin.Net.Interfaces.Clients.SpotApi.IKucoinClientSpotApiAccount.GetRiskLimitAsync(System.Nullable{System.Boolean},System.Threading.CancellationToken)">
+        <member name="M:Kucoin.Net.Interfaces.Clients.SpotApi.IKucoinClientSpotApiAccount.GetRiskLimitCrossMarginAsync(System.Threading.CancellationToken)">
             <summary>
-            Get cross or isolated margin risk limit
+            Get cross margin risk limit
             </summary>
-            <param name="isolated">Request isolated info, default cross info is returned</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Kucoin.Net.Interfaces.Clients.SpotApi.IKucoinClientSpotApiAccount.GetRiskLimitIsolatedMarginAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get isolated margin risk limit
+            </summary>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
@@ -6878,6 +6887,73 @@
             <summary>
             Prevision
             </summary>
+        </member>
+        <member name="T:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitCrossMargin">
+            <summary>
+            Risk limit info
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitCrossMargin.Asset">
+            <summary>
+            The asset
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitCrossMargin.BorrowMaxQuantity">
+            <summary>
+            Max borrow quantity
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitCrossMargin.BuyMaxQuantity">
+            <summary>
+            Max buy quantity
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitCrossMargin.Precision">
+            <summary>
+            Prevision
+            </summary>
+        </member>
+        <member name="T:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin">
+            <summary>
+            Risk limit info
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin.Asset">
+            <summary>
+            The asset
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin.BaseMaxBorrowQuantity">
+            <summary>
+            Max borrow quantity
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin.QuoteMaxBorrowQuantity">
+            <summary>
+            Max borrow quantity
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin.BaseMaxBuyQuantity">
+            <summary>
+            BaseMax buy quantity
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin.QuoteMaxBuyQuantity">
+            <summary>
+            Quote Max buy quantity
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin.BasePrecision">
+            <summary>
+            Base Precision
+            </summary>
+                    
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinRiskLimitIsolatedMargin.QuotePrecision">
+            <summary>
+            Quote Precision
+            </summary>
+                    
         </member>
         <member name="T:Kucoin.Net.Objects.Models.Spot.KucoinSubUser">
             <summary>

--- a/Kucoin.Net/Kucoin.Net.xml
+++ b/Kucoin.Net/Kucoin.Net.xml
@@ -488,6 +488,9 @@
         <member name="M:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiExchangeData.GetMarginTradeHistoryAsync(System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="M:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiExchangeData.GetMarginTradingPairConfigurationAsync(System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="T:Kucoin.Net.Clients.SpotApi.KucoinClientSpotApiTrading">
             <inheritdoc />
         </member>
@@ -2698,6 +2701,14 @@
             </summary>
             <param name="asset">The asset</param>
             <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Kucoin.Net.Interfaces.Clients.SpotApi.IKucoinClientSpotApiExchangeData.GetMarginTradingPairConfigurationAsync(System.Threading.CancellationToken)">
+            <summary>
+            Get Margin Trading Pair ConfigurationAsync
+            <para><a href="https://docs.kucoin.com/#query-isolated-margin-trading-pair-configuration" /></para>
+            </summary>
+            <param name="ct">Cancellation token</param> 
             <returns></returns>
         </member>
         <member name="T:Kucoin.Net.Interfaces.Clients.SpotApi.IKucoinClientSpotApiTrading">
@@ -7173,6 +7184,71 @@
         <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradeFee.MakerFeeRate">
             <summary>
             Fee rate for trades as maker
+            </summary>
+        </member>
+        <member name="T:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration">
+            <summary>
+            Trading Pair Configuration
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.Asset">
+            <summary>
+            The asset
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.SymbolName">
+            <summary>
+            Symbol Name
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.BaseCurrency">
+            <summary>
+            Base Currency
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.QuoteCurrency">
+            <summary>
+            Quote Currency
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.MaxLeverage">
+            <summary>
+            Max Leverage
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.FlDebtRatio">
+            <summary>
+            FlDebtRatio
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.TradeEnable">
+            <summary>
+            Trade Enable
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.AutoRenewMaxDebtRatio">
+            <summary>
+            Auto Renew Max Debt Ratio
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.BaseBorrowEnable">
+            <summary>
+            Base Borrow Enable
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.QuoteBorrowEnable">
+            <summary>
+            Quote Borrow Enable
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.BaseTransferInEnable">
+            <summary>
+            Base Transfer In Enable
+            </summary>
+        </member>
+        <member name="P:Kucoin.Net.Objects.Models.Spot.KucoinTradingPairConfiguration.QuoteTransferInEnable">
+            <summary>
+            Quote Transfer In Enable
             </summary>
         </member>
         <member name="T:Kucoin.Net.Objects.Models.Spot.KucoinTransferableAccount">

--- a/Kucoin.Net/Objects/Models/Spot/KucoinRiskLimitCrossMargin.cs
+++ b/Kucoin.Net/Objects/Models/Spot/KucoinRiskLimitCrossMargin.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+
+namespace Kucoin.Net.Objects.Models.Spot
+{
+    /// <summary>
+    /// Risk limit info
+    /// </summary>
+    public class KucoinRiskLimitCrossMargin
+    {
+        /// <summary>
+        /// The asset
+        /// </summary>
+        [JsonProperty("currency")]
+        public string Asset { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Max borrow quantity
+        /// </summary>
+        [JsonProperty("borrowMaxAmount")]
+        public decimal BorrowMaxQuantity { get; set; }
+
+        /// <summary>
+        /// Max buy quantity
+        /// </summary>
+        [JsonProperty("buyMaxAmount")]
+        public decimal BuyMaxQuantity { get; set; }
+
+        /// <summary>
+        /// Prevision
+        /// </summary>
+        public int Precision { get; set; }
+    }
+}

--- a/Kucoin.Net/Objects/Models/Spot/KucoinRiskLimitIsolatedMargin.cs
+++ b/Kucoin.Net/Objects/Models/Spot/KucoinRiskLimitIsolatedMargin.cs
@@ -8,10 +8,10 @@ namespace Kucoin.Net.Objects.Models.Spot
     public class KucoinRiskLimitIsolatedMargin
     {
         /// <summary>
-        /// The asset
+        /// The Symbol
         /// </summary>
         [JsonProperty("symbol")]
-        public string Asset { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
 
         /// <summary>
         /// Max borrow quantity

--- a/Kucoin.Net/Objects/Models/Spot/KucoinRiskLimitIsolatedMargin.cs
+++ b/Kucoin.Net/Objects/Models/Spot/KucoinRiskLimitIsolatedMargin.cs
@@ -1,0 +1,54 @@
+﻿using Newtonsoft.Json;
+
+namespace Kucoin.Net.Objects.Models.Spot
+{
+    /// <summary>
+    /// Risk limit info
+    /// </summary>
+    public class KucoinRiskLimitIsolatedMargin
+    {
+        /// <summary>
+        /// The asset
+        /// </summary>
+        [JsonProperty("symbol")]
+        public string Asset { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Max borrow quantity
+        /// </summary>
+        [JsonProperty("baseMaxBorrowAmount")]
+        public decimal BaseMaxBorrowQuantity { get; set; }
+
+        /// <summary>
+        /// Max borrow quantity
+        /// </summary>
+        [JsonProperty("quoteMaxBorrowAmount")]
+        public decimal QuoteMaxBorrowQuantity { get; set; }
+
+        /// <summary>
+        /// BaseMax buy quantity
+        /// </summary>
+        [JsonProperty("baseMaxBuyAmount")]
+        public decimal BaseMaxBuyQuantity { get; set; }
+
+        /// <summary>
+        /// Quote Max buy quantity
+        /// </summary>
+        [JsonProperty("quoteMaxBuyAmount")]
+        public decimal QuoteMaxBuyQuantity { get; set; }
+
+        /// <summary>
+        /// Base Precision
+        /// </summary>
+        ///         
+        [JsonProperty("basePrecision")]
+        public int BasePrecision { get; set; }
+
+        /// <summary>
+        /// Quote Precision
+        /// </summary>
+        ///         
+        [JsonProperty("quotePrecision")]
+        public int QuotePrecision { get; set; }
+    }
+}

--- a/Kucoin.Net/Objects/Models/Spot/KucoinTradingPairConfiguration.cs
+++ b/Kucoin.Net/Objects/Models/Spot/KucoinTradingPairConfiguration.cs
@@ -1,0 +1,82 @@
+﻿using Newtonsoft.Json;
+
+namespace Kucoin.Net.Objects.Models.Spot
+{
+    /// <summary>
+    /// Trading Pair Configuration
+    /// </summary>
+    public class KucoinTradingPairConfiguration
+    {
+        /// <summary>
+        /// The asset
+        /// </summary>
+        [JsonProperty("symbol")]
+        public string Asset { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Symbol Name
+        /// </summary>
+        [JsonProperty("symbolName")]
+        public string SymbolName { get; set; }
+
+        /// <summary>
+        /// Base Currency
+        /// </summary>
+        [JsonProperty("baseCurrency")]
+        public string BaseCurrency { get; set; }
+
+        /// <summary>
+        /// Quote Currency
+        /// </summary>
+        [JsonProperty("quoteCurrency")]
+        public string QuoteCurrency { get; set; }
+
+        /// <summary>
+        /// Max Leverage
+        /// </summary>
+        [JsonProperty("maxLeverage")]
+        public int MaxLeverage { get; set; }
+
+        /// <summary>
+        /// FlDebtRatio
+        /// </summary>
+        [JsonProperty("flDebtRatio")]
+        public decimal FlDebtRatio { get; set; }
+
+        /// <summary>
+        /// Trade Enable
+        /// </summary>
+        [JsonProperty("tradeEnable")]
+        public bool TradeEnable { get; set; }
+
+        /// <summary>
+        /// Auto Renew Max Debt Ratio
+        /// </summary>
+        [JsonProperty("autoRenewMaxDebtRatio")]
+        public decimal AutoRenewMaxDebtRatio { get; set; }
+
+        /// <summary>
+        /// Base Borrow Enable
+        /// </summary>
+        [JsonProperty("baseBorrowEnable")]
+        public bool BaseBorrowEnable { get; set; }
+
+        /// <summary>
+        /// Quote Borrow Enable
+        /// </summary>
+        [JsonProperty("quoteBorrowEnable")]
+        public bool QuoteBorrowEnable { get; set; }
+
+        /// <summary>
+        /// Base Transfer In Enable
+        /// </summary>
+        [JsonProperty("baseTransferInEnable")]
+        public bool BaseTransferInEnable { get; set; }
+
+        /// <summary>
+        /// Quote Transfer In Enable
+        /// </summary>
+        [JsonProperty("quoteTransferInEnable")]
+        public bool QuoteTransferInEnable { get; set; }
+    }
+}

--- a/Kucoin.Net/Objects/Models/Spot/KucoinTradingPairConfiguration.cs
+++ b/Kucoin.Net/Objects/Models/Spot/KucoinTradingPairConfiguration.cs
@@ -8,10 +8,10 @@ namespace Kucoin.Net.Objects.Models.Spot
     public class KucoinTradingPairConfiguration
     {
         /// <summary>
-        /// The asset
+        /// The Symbol
         /// </summary>
         [JsonProperty("symbol")]
-        public string Asset { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
 
         /// <summary>
         /// Symbol Name
@@ -20,16 +20,16 @@ namespace Kucoin.Net.Objects.Models.Spot
         public string SymbolName { get; set; }
 
         /// <summary>
-        /// Base Currency
+        /// Base Asset
         /// </summary>
         [JsonProperty("baseCurrency")]
-        public string BaseCurrency { get; set; }
+        public string BaseAsset { get; set; }
 
         /// <summary>
-        /// Quote Currency
+        /// Quote Asset
         /// </summary>
         [JsonProperty("quoteCurrency")]
-        public string QuoteCurrency { get; set; }
+        public string QuoteAsset { get; set; }
 
         /// <summary>
         /// Max Leverage


### PR DESCRIPTION
For endpoint risk limit, if parameter isolated is passed the return object is different from cross margin (default)

/api/v1/risk/limit/strategy?marginModel=isolated

https://docs.kucoin.com/#get-margin-account