### PR TITLE
Added new AccountType.

### DIFF
--- a/Kucoin.Net/Converters/AccountTypeConverter.cs
+++ b/Kucoin.Net/Converters/AccountTypeConverter.cs
@@ -20,6 +20,7 @@ namespace Kucoin.Net.Converters
             new KeyValuePair<AccountType, string>(AccountType.Margin, _useCaps ? "MARGIN" : "margin"),
             new KeyValuePair<AccountType, string>(AccountType.Pool, _useCaps ? "POOL" : "pool"),
             new KeyValuePair<AccountType, string>(AccountType.Isolated, _useCaps ? "ISOLATED" : "isolated"),
+            new KeyValuePair<AccountType, string>(AccountType.HighFrequency, _useCaps ? "TRADE_HF" : "trade_hf")
         };
     }
 }

--- a/Kucoin.Net/Enums/AccountType.cs
+++ b/Kucoin.Net/Enums/AccountType.cs
@@ -24,6 +24,10 @@
         /// <summary>
         /// Isolated marging account
         /// </summary>
-        Isolated
+        Isolated,
+        /// <summary>
+        /// High Frequency (PRO Account) account
+        /// </summary>
+        HighFrequency
     }
 }

--- a/Kucoin.Net/Kucoin.Net.xml
+++ b/Kucoin.Net/Kucoin.Net.xml
@@ -761,6 +761,11 @@
             Isolated marging account
             </summary>
         </member>
+        <member name="F:Kucoin.Net.Enums.AccountType.HighFrequency">
+            <summary>
+            High Frequency (PRO Account) account
+            </summary>
+        </member>
         <member name="T:Kucoin.Net.Enums.BizType">
             <summary>
             BizType Description


### PR DESCRIPTION
Adding new account type.

High frequency API documentation: https://docs.kucoin.com/spot-hf/#quick-start

Quick start:
1). Use POST /api/v2/accounts/inner-transfer to transfer funds to the high-frequency account
2). Use POST /api/v1/hf/orders to place high-frequency orders
At present, high-frequency accounts can only be operated through api, and cannot be queried through the web

hf-account is only applicable to the spot, no Margin, no Futures.