### PR TITLE
Updated KucoinRestClientFuturesApiExchangeData GetTickersAsync request weight from 15 to 5

### DIFF
--- a/Kucoin.Net/Clients/FuturesApi/KucoinRestClientFuturesApiExchangeData.cs
+++ b/Kucoin.Net/Clients/FuturesApi/KucoinRestClientFuturesApiExchangeData.cs
@@ -60,7 +60,7 @@ namespace Kucoin.Net.Clients.FuturesApi
         /// <inheritdoc />
         public async Task<HttpResult<KucoinFuturesTick[]>> GetTickersAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/allTickers", KucoinExchange.RateLimiter.PublicRest, 15);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v1/allTickers", KucoinExchange.RateLimiter.PublicRest, 5);
             return await _baseClient.SendAsync<KucoinFuturesTick[]>(request, null, ct).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
According to the offical docs, the `allTickers` request has a weight of 5.
https://www.kucoin.com/docs-new/rest/futures-trading/market-data/get-all-tickers